### PR TITLE
Update system.twinrc

### DIFF
--- a/system.twinrc
+++ b/system.twinrc
@@ -1,70 +1,129 @@
-# Copyright (C) 2000 by Massimiliano Ghilardi
+#________________________________________________________________________________
+#                                                                                |
+# Copyright (C) 2000 by Massimiliano Ghilardi                                    |
+#                                                                                |
+# This program is free software; you can redistribute it and/or modify           |
+# it under the terms of the GNU General Public License as published by           |
+# the Free Software Foundation; either version 2 of the License, or              |
+# (at your option) any later version.                                            |
+#________________________________________________________________________________|
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2 of the License, or
-# (at your option) any later version.
-#
-#
-#
-# This file contains the configuration for twin look-n-feel.
+
+# This file contains the configuration for TWin look-n-feel.
 # By default, it is installed as ${libdir}/twin/system.twinrc
-# and, provided twin is compiled with RC parser support,
+# and, provided TWin is compiled with RC parser support,
 # it is used as fallback configuration in case the user does not
-# have his own ${HOME}/.twinrc
+# have their own ${HOME}/.twinrc
 #
-# to customize twin user interface, just copy this file in your
-# home directory as `.twinrc' and edit it to your tastes.
-#
-
-# file syntax:
+# To customize TWin user interface, copy this file in your
+# home directory as `.twinrc' and edit it as desired.
 # 
-# a hash sign '#' at the beginning of a line means the line
-# is a comment (you are already reading such a comment!)
+# A hash sign (#) at the beginning of a line means the line is a comment (you
+# are reading such a comment). Comments do not affect the function of TWin,
+# they exist solely to provide instruction and description for the user.
 #
-# Many different commands are recognized, and are listed below.
-# A quick summary of all keywords can be found at the end of this file.
+# Many different commands and keywords are recognized. The glossary at the
+# end of this file contains the complete list.
 
-# First command:
+#________________________________________________________________________________
+#__                       _______________________________________________________|
+#__ Basic startup options _______________________________________________________|
+#________________________________________________________________________________|
 #
-# set screen background
-Background 1 High Black On Blue (
-   "\xb1"
-)
+
+# Override the defaults specified at compile time:
+#
+# set shadows to 3x2 and enable them
+GlobalFlags Shadows 2 1 +Shadows
+#
+# disable blink/high background
+GlobalFlags -Blink
+#
+# do not force cursor always visible
+GlobalFlags -CursorAlways
+#
+# disable edge screen scrolling
+GlobalFlags -ScreenScroll
+#
+# do not hide the menu
+GlobalFlags -MenuHide
+#
+# disable menu information row
+GlobalFlags -MenuInfo
+#
+# don't relax menu navigation
+GlobalFlags -MenuRelax
+
+
+# To automatically open a terminal on startup:
+#
+ExecTty "" ; Wait "Twin Term"
+
+
+# To automatically open a maximized terminal on startup, add
+# the value "Maximize":
+#
+# ExecTty "" ; Wait "Twin Term" ; Maximize
+
+
+# To automatically load the socket server on startup:
+#
+# Module "socket" On
+#
+
+
+# To automatically load term on startup:
+#
+# Module "term" On
+
+#________________________________________________________________________________
+#__         _____________________________________________________________________|
+#__ Screens _____________________________________________________________________|
+#________________________________________________________________________________|
+#
+
 # the screen `1' is created by twin at startup,
 # so we do not need to `AddScreen 1',
-# and `High Black On Blue' means `high intensity black' (i.e. gray) foreground
-# on `blue' background.
+
+
+# Set screen background color:
 #
-# the complete list of colors is:
+# The complete list of colors is:
+#
 # Black Blue Green Cyan Red Magenta Yellow White
 #
-# and `High' can be applied both to foreground and background.
-# depending on the display you use, `High' background may actually blink.
+# The prefix value "High" can be applied to any of the above colors to
+# change it, and can be applied both to foreground and background.
+# Depending on the display you use, `High' background may actually blink.
 #
-# the strings inside ( ) are just the screen background,
-# each string representing a line.
+# As an example, `High Black On Blue' would mean `high intensity black' (i.e.
+# gray) foreground on `blue' background.
 #
-# every time you must write a string, you can use hexadecimal codes like "\xb1"
-# or octal codes like "\261", and double quotes surrounding the string
-# are only needed to protect special characters (i.e. parentheses,
-# non-alphanumerical chars, etc.). Sequences like "\?" where ? is a character
-# have the same meaning as in C language:
-# "\"" is a string containing a double quote,
-# "\n" is a newline, and so on.
+# The mixture of the two values creates the screen color.
+#
+#The strings inside ( ) are the screen background, each string representing
+# a line.
+#
+Background 1 Red On Blue (
+   "\xb1"
+)
 
+#________________________________________________________________________________
+#__                   ___________________________________________________________|
+#__ Menus and Windows ___________________________________________________________|
+#________________________________________________________________________________|
+#
 
+# Create the common part of all menus:
 #
-# create the common part of all menus
+# Quotes are needed to protect reserved names or strings containing
+# non-alphanumerical characters. Parenthesis '(' and ')' are used to group
+# together a list.
 #
-# you need quotes to protect reserved names
-# or strings containing non-alphanumerical chars.
-# again, parenthesis '(' and ')' are used to group together a list
-#
-# this creates the menuitem " Window ", shared by all applications,
+# This creates the menuitem " Window ", shared by all applications,
 # with the contents you see below.
 #
-# the command `Nop' is a do-nothing command used to insert a linebreak.
+# The command `Nop' is a do-nothing command used to insert a linebreak.
 # `_Next' is a user function (all other ones are predefined by twin) and
 # is defined below.
 #
@@ -90,54 +149,55 @@ AddToMenu " Window " (
    " Kill Client " Kill
 )
 
+
+# Define the user function `_Next':
 #
-# define the user function `_Next' :
-# group commands in '(' ')' and put either a newline or a ';'
+# Group commands in '(' ')' and put either a newline or a ';'
 # after each command. `Window 1' means first window, while
 # `Window 0' is the currently focused window.
 #
 AddToFunc _Next ( Lower; Window 1; Focus; )
 
-# this would be exactly the same
+
+# Or this would do exactly the same thing:
 #
 # AddToFunc _Next (
 #   Lower
 #   Window 1
 #   Focus
 # )
-#
-# or you can even split the function definition:
+
+
+# Or you can even split the function definition:
 #
 # AddToFunc _Next ( Lower; Window 1; )
 # AddToFunc _Next (
 #   Focus
 # )
-#
 
 
-#
-# These are not needed... and they override
-# the borders defined by Alternate Font
+# The following are not needed. If used, they can override
+# the borders defined by Alternate Font:
 #
 # Border "*" Inactive (
-#   "⁄ƒø"
-#   "≥ ≥"
-#   "¿ƒŸ"
+#   "√ö√Ñ¬ø"
+#   "¬≥ ¬≥"
+#   "√Ä√Ñ√ô"
 # )
 #
 # Border "*" Active (
-#    "…Õª"
-#    "∫ ∫"
-#    "»Õº"
+#    "√â√ç¬ª"
+#    "¬∫ ¬∫"
+#    "√à√ç≈í"
 # )
-#
-# But maybe you feel funky and want different borders
-# for different windows:
+
+
+# If you want different borders for different windows:
 #
 # Border "*Term*" Inactive (
-#    " ﬂ "
-#    "› ﬁ"
-#    " ‹ "
+#    " √ü "
+#    "√ù √û"
+#    " √ú "
 # )
 #
 # Border "Clock" Active (
@@ -147,158 +207,117 @@ AddToFunc _Next ( Lower; Window 1; Focus; )
 # )
 #
 # Border "Tw*" Active (
-#    "÷Õ∑"
-#    "≥ ≥"
-#    "”ÕΩ"
+#    "√ñ√ç¬∑"
+#    "¬≥ ¬≥"
+#    "√ì√ç≈ì"
 # )
-#
-# menu windows have no name... and are always considered Inactive
+
+
+# Menu windows can be used. They have no name and are always
+# considered Inactive:
 #
 # Border "" Inactive (
-#   "€ﬂ€"
-#   "€ €"
-#   "€‹€"
+#   "√õ√ü√õ"
+#   "√õ √õ"
+#   "√õ√ú√õ"
 # )
 
+#________________________________________________________________________________
+#__                   ___________________________________________________________|
+#__ Keyboard controls ___________________________________________________________|
+#________________________________________________________________________________|
+#
 
-
+# Keyboard bindings syntax:
 #
-# create the buttons on window top border.
-# allowed buttons range from 0 to 9.
-# 
-# syntax:
-# Button <number> "shape" {Left|Right} [[+|-]<position>]
-# 
-# creates button <number> with given "shape", either on Left or Right
-# of window title. Optionally, you can control where exactly to place it:
+# Key <flags> <name> <command>
 #
-# `Left +<n>' or `Right +<n>' leaves <n> free spaces between this button
-# and the last one on the same side.
+# Where:
 #
-# `Left <n>' or `Right <n>' specifies exact distance between button and
-# window Left (Right) edge.
+# Key = The command to create a keybinding.
 #
-# `Left -<n>' or `Right -<n>' says to place the button <n> characters nearer
-# to the border than just `Left' or `Right', possibly intersecting
-# other buttons.
-
+# <flags> = An optional value. Except on X11 display, TWin can detect flags only
+# by deducing them from the ASCII sequences it receives from the keyboard, so
+# Shift is almost useless and not all keys combined with Ctrl and Alt make
+# sense (i.e. they must produce a unique, identificable ASCII sequence).
 #
-# WARNING: Button 0 must ALWAYS be the close button...
-#
-Button 0 "[]" Left
-Button 1 "\x12\x12" Right
-Button 2 "><" Right
-#
-# a maximize/fullscreen button. feel free to uncomment :-)
-# Button 3 "+-" Right +1
-
-
-#
-# override the Options specified at compile time
-#
-# set shadows to 3x2 and enable them
-GlobalFlags Shadows 3 2 +Shadows
-#
-# disable blink/high background
-GlobalFlags -Blink
-#
-# do not force cursor always visible
-GlobalFlags -CursorAlways
-#
-# disable edge screen scrolling
-GlobalFlags -ScreenScroll
-#
-# do not hide the menu
-GlobalFlags -MenuHide
-#
-# disable menu information row
-GlobalFlags -MenuInfo
-#
-# don't relax menu navigation
-GlobalFlags -MenuRelax
-#
-#
-# choose the mouse button used for click-to-focus,
-# for text selection and to activate window gadgets.
-# 1 means Left, 2 means Middle, 3 means Right.
-# this also implies a 'Focus' action when clicking in a non-focused window.
-#
-GlobalFlags ButtonSelection 1
-#
-# choose the mouse button used to paste text selection
-#
-GlobalFlags ButtonPaste 2
-
-#
-# keyboard bindings syntax:
-#
-# Key <flags> <name> <function>
-#
-# <flags> is optional and can be one or more of
 #   Shift
 #   Ctrl
 #   Alt
-# remember anyway that except on X11 display twin can detect these flags
-# only deducing them from the ASCII sequences it receives from the keyboard,
-# so Shift is almost useless and not all keys combined with Ctrl and Alt
-# make sense (i.e. they must produce a unique, identificable ASCII sequence)
 #
-# <name> is the name of the key as in libTwkeys.h, without the TW_ prefix.
+# <name> = The name of the key as in libTwkeys.h, without the TW_ prefix.
 # To be safe, <name> should be quoted. some examples:
+#
 #   "Tab"   "Return"  "Escape"  "BackSpace"
 #   "Left"  "Up"      "Right"   "Down"
 #   "Prior" ("Page_Up")         "Next"  ("Page_Down")
 #   "Home"  "End"     "Insert"  "Delete"
 #   "Pause" "Num_Lock"
 #   "F1" "F2" "F3" "F4" "F5" "F6" "F7" "F8" "F9" "F10" "F11" "F12"
-# or any ASCII character, also in double quotes:
-#   "A"  "[" "\xFF" and so on
 #
+# Or any ASCII character, also in double quotes, for example:
+#
+#   "A"  "[" "\xFF"
+#
+# <command> = What the binding does. See the commands glossary below.
 
-#
+
 # Both PAUSE and F12 pop up the menu. Feel free to use any other key.
 #
 Key  "Pause"   Interactive Menu
 Key  "F12"     Interactive Menu
 
 
-#
-# this is a user contributed idea: ALT-TAB to cycle through windows.
+# A user contributed idea: ALT-TAB to cycle through windows:
 #
 Key Alt "Tab" _Next
 
 
-#
 # Other nifty ideas.
 # These will work only on display drivers that support abstract keys.
 # Currently requires one of: `tty' with Linux raw keyboard, `gfx' or `X11'.
 #
-
 #
 # ALT-UP spawns a new terminal.
 #
 Key Alt   "Up"    ExecTty ""
-
 #
 # SHIFT-PAGEUP scrolls up focused window
 #
 Key Shift "Prior" Scroll +0 -10
-
-
 #
 # SHIFT-PAGEDOWN scrolls down focused window
 #
 Key Shift "Next"  Scroll +0 +10
 
+#________________________________________________________________________________
+#__               _______________________________________________________________|
+#__ Mouse buttons _______________________________________________________________|
+#________________________________________________________________________________|
+#                                                                                |
+#  ############################################################################  |
+# | Note: both window controls and mouse buttons are called buttons, so it may | |
+# | be a bit confusing. Look closely at the descriptions to understand whether | |
+# | the word "Button" refers to a physical mouse button or a window control.   | |
+#  ############################################################################  |
+#________________________________________________________________________________|
+#
 
+# Mouse bindings syntax:
 #
-# mouse bindings syntax:
+# Mouse <buttons-list> <context> <command>
 #
-# Mouse <buttons-list> <context> <function>
+# Where:
 #
+# Mouse = The command to address mouse buttons.
+# 
+# <buttons-list> = Mouse button values. 1 means Left, 2 means Middle,
+# 3 means Right. Can be used in combination to bind more than one button to a
+# command, i.e. "12" "13" "23" "123".
 #
-# context is a string consisting of one or more of the following:
-#  0..9 corresponding button in window title
+# <context> = a string consisting of one or more of the following:
+#
+# 0-9   button number 0-9 in window title bar (see: Window buttons)
 #  C    window resize corner
 #  T    window title bar
 #  S    window sides
@@ -309,104 +328,232 @@ Key Shift "Next"  Scroll +0 +10
 #  R    root (screen background)
 #  A    any of the above
 #
-
+# <command> = What the binding does. See the commands glossary below.
 #
-# mouse bindings: left click on button 0 graciously closes the window
+# There are also some more subtle ways to use the mouse buttons. CLICK
+# and RELEASE can be a different control than simply CLICK.
 #
-Mouse   1   0  Close
-
-# this is subtle: doing
+# `H' means `hold'.
+#
+# `C' means `click', but it's the default and can be omitted. However, used in
+# combination with 'H' it can be used to execute on PRESS and the again on
+# CLICK by specifying `HC', for example:
+#
 #   Mouse  H1   0  Close
+#
 # instead of
+#
 #   Mouse   1   0  Close
-# would close the window when you PRESS mouse left button on window close button,
-# NOT when you CLICK (i.e. PRESS, then RELEASE) on it!
 #
-# (note: `H' means `hold'. there is also `C' which means `click',
-# but it's the default and can be omitted, unless you want you want to use
-# them together, meaning to execute on PRESS and again on CLICK,
-# by specifying `HC' )
+# ...would close the window when you PRESS mouse left button on window close
+# button, NOT when you CLICK (i.e. PRESS, then RELEASE) on it!
+
+
+# Raise a backgrounded window by right clicking on the window inside:
 #
+Mouse H3 I Raise
 
-# any mouse click on button 1 does RaiseLower
-Mouse 123  1  RaiseLower
 
-# any mouse click on button 2 does Roll / UnRoll
-Mouse 123  2  Roll Toggle
-
-# these are do-nothing if Button 3 above is commented out
+# Choose the mouse button used for click-to-focus, for text selection, and
+# to activate window gadgets.
 #
-# mouse left click on button 3 does Maximize
-Mouse  1   3  Maximize
-# mouse middle click on button 3 does FullScreen
-Mouse  2   3  FullScreen
+GlobalFlags ButtonSelection 3
 
-# holding mouse left button on window title or sides does interactive move
-Mouse H1  TS  Interactive Move
 
-# mouse left on window resize corner does interactive resize
+# Choose the mouse button used to paste text selection:
+#
+GlobalFlags ButtonPaste 2
+
+
+# holding mouse right button on window title or sides does interactive move
+Mouse H123  TS  Interactive Move
+
+
+# mouse right on window resize corner does interactive resize
 # mouse-based window resize works "as expected" only on window resize corner
 # (try yourself to bind some window button to Interactive Resize and see...)
 #
-Mouse H1   C  Interactive Resize
+Mouse H3   C  Interactive Resize
+Mouse H1   I  Interactive Resize
 
-# mouse left on window bars does interactive scroll
+
+# mouse right on window bars does interactive scroll
 # unluckily, mouse-based window scrolling works properly ONLY
 # on window bars...
 #
-Mouse H1  B  Interactive Scroll
+Mouse H3  B  Interactive Scroll
 
-# mouse left on root unfocuses currently focused window
+
+# mouse right on root unfocuses currently focused window
 # 
 # you can create functions as complex as you like and use them
 # just like built-in functions...
 AddToFunc _UnFocus ( Window 0; Focus Off; )
-Mouse H1  R _UnFocus
+Mouse H3  R _UnFocus
+
 
 # middle button on root opens window list
 Mouse H2  R  WindowList
 
-# Choose your favorite setup... for twin-classic menus, which appear only
-# after you press right mouse button, use this:
+
+# For twin-classic menus, which appear only after you press right mouse
+# button, use this:
 #
-# # right button always opens the menu
-# Mouse H3  A  Interactive Menu
-# # mouse left on menu-bar does screen resize
-# Mouse H1  M  Interactive Screen
+# Right button always opens the menu:
+#
+Mouse H3  A  Interactive Menu
+#
+# Mouse left on menu-bar does screen resize:
+#
+Mouse H1  M  Interactive Screen
 
 
-# Otherwise you can use turbovision style menus:
-# they always stay visible and are selected with left button
+# You can also use turbovision style menus. They always stay visible and
+# are selected with right button:
+#
 # _on_menu_bar_
 #
-# left button on menu-bar opens the menu
-Mouse H1  M  Interactive Menu
-# in this case, use mouse right button on menu-bar for screen resize
-Mouse H3  M  Interactive Screen
+# Right button on menu-bar opens the menu:
+Mouse H3  M  Interactive Menu
+# In this case, use mouse left button on menu-bar for screen resize:
+Mouse H1  M  Interactive Screen
 
-# # Or better yet, create your personal style!
-# #
-
-
-# now you may want some initial client...
-# uncomment to pop-up a terminal and maximize it.
-# `;' is the same as a newline...
+#________________________________________________________________________________
+#__                                         _____________________________________|
+#__ Window button/Mouse button intersection _____________________________________|
+#________________________________________________________________________________|
+#                                                                                |
+#  ############################################################################  |
+# | Note: both window controls and mouse buttons are called buttons, so it may | |
+# | be a bit confusing. Look closely at the descriptions to understand whether | |
+# | the word "Button" refers to a physical mouse button or a window control.   | |
+#  ############################################################################  |
+#________________________________________________________________________________|
 #
-ExecTty "" ; Wait "Twin Term" ; Maximize
 
-# for all users too lazy to manually load the socket server from the menu:
+# any mouse click on button 0 closes the window
 #
-# Module "socket" On
+Mouse  123  0  Close
+
+
+# any mouse click on button 1 does RaiseLower
 #
-# you may also want:
-# Module "term" On
+Mouse  123  1  RaiseLower
 
 
-
-
+# any mouse click on button 2 does Roll/UnRoll
 #
-# list of all RC commands available for ~/.twinrc
-# 
+Mouse  123  2  Roll Toggle
+
+
+# any mouse click on button 0 closes the window
+#
+Mouse  123  3  Close
+
+
+# any mouse click on button 1 does RaiseLower
+#
+Mouse  123  4  RaiseLower
+
+
+# any mouse click on button 2 does Roll/UnRoll
+#
+Mouse  123  5  Roll Toggle
+
+
+# The following bindings only work if the maximize/fullscreen button is
+# uncommented (created):
+#
+# mouse right click on button 3 does Maximize
+#
+#Mouse  3   3  Maximize
+#
+# mouse middle click on button 3 does FullScreen
+#
+#Mouse  2   3  FullScreen
+
+#________________________________________________________________________________
+#__                ______________________________________________________________|
+#__ Window buttons ______________________________________________________________|
+#________________________________________________________________________________|
+#                                                                                |
+#  ############################################################################  |
+# | Note: both window controls and mouse buttons are called buttons, so it may | |
+# | be a bit confusing. Look closely at the descriptions to understand whether | |
+# | the word "Button" refers to a physical mouse button or a window control.   | |
+#  ############################################################################  |
+#________________________________________________________________________________|
+#
+
+# Window Button syntax:
+#
+# Button <number> "shape" {Left|Right} [[+|-]<position>]
+#
+# Where:
+#
+# Button = The command for a window button.
+#
+# <number> = The identifier to distinguish between buttons. Allowed numerical
+# range is 0 to 9.
+#
+# "shape" = ASCII characters are allowed for creating a symbol on the button.
+#
+# {Left|Right} = The side of the window bar where the button will be based.
+#
+# [[+|-]<position>] = Options for specific positioning relative to the edge of
+# the side set in {Left|Right}. Use only one:
+#
+# '<n>' specifies the distance between the button and the edge
+# '+<n>' leaves <n> free spaces between this button and the preceding one
+# '-<n>' says to place the button <n> characters nearer to the border than just
+# `Left' or `Right', possibly intersecting other buttons.
+#
+# WARNING: Button 0 must ALWAYS be the close button, though close can be
+# duplicated as another button number (see above).
+#
+# Also, this is weird but the button order/sequence as it appears on the window
+# bar is dependent on the order/sequence in which they are copied below. In
+# other words, if any of the lines below were to be taken out and then placed
+# above or below where they previously had been, their respective buttons would
+# appear in a different sequence on the window bar - even if the lines are typed
+# exactly the same. Yeah I don't know why that was a good idea but there it is.
+#
+Button 1 "\x12\x12" Right
+Button 2 "><" Right +1
+Button 0 "[]" Right +1
+Button 4 "\x12\x12" Left
+Button 5 "><" Left +1
+Button 3 "[]" Left +1
+
+
+# This creates a maximize/fullscreen button.
+#
+# Button 3 "+-" Right +1
+
+#________________________________________________________________________________
+#__                                                                        ______|
+#__ glossary of all available RC commands for ~/.twinrc (this config file) ______|
+#________________________________________________________________________________|
+#                                                                                |
+#  ############################################################################  |
+# | Note: every time you must write a string, you can use hexadecimal codes    | |
+# | like "\xb1" or octal codes like "\261". Double quotes surrounding the      | |
+# | string are only needed to protect special characters (i.e. parentheses,    | |
+# | non-alphanumerical chars, etc.).                                           | |
+# |                                                                            | |
+# | Sequences like "\?" where ? is a character                                 | |
+# | have the same meaning as in the C language:                                | |
+# |                                                                            | |
+# | "\"" is a string containing a double quote                                 | |
+# | "\n" is a newline                                                          | |
+# |                                                                            | |
+# | And so on.                                                                 | |
+# |                                                                            | |
+# | `;' is the same as a newline.                                              | |
+#  ############################################################################  |
+#________________________________________________________________________________|
+#
+
 # AddScreen <screen name>
 # # create a new virtual screen
 # 
@@ -431,9 +578,9 @@ ExecTty "" ; Wait "Twin Term" ; Maximize
 # Beep
 # 
 # Border <wildcard-pattern> {Active|Inactive} (
-#   "…Õª"
-#   "∫ ∫"
-#   "»Õº"
+#   "√â√ç¬ª"
+#   "¬∫ ¬∫"
+#   "√à√ç≈í"
 # )
 #
 # Button <n> "<shape>" [+|-[<numeric pos>|Left|Right]]


### PR DESCRIPTION
- reorganized the contents of the config file into clearer sections prefaced by textmode marquis, clarified language, changed multiple "he" references to be gender-neutral, condensed some descriptions to be more concise, removed some redundancies

- left-handed mouse operation (obviously not essential, but in any case all clicks described below should be reversed for right handed operation)

- aesthetic change: background color

- window button reorganization: mirrored them; users that don't know about configuring gpm may find it tedious to drag a slow mouse cursor from corner to corner, so placing the same controls at both upper left and right corners may make manual manipulation easier

- clicking open spaces on window now focuses the window, more like modern desktop environments

- left clicking open spaces in window now allows resizing; idea borrowed from openbox's alt+left click resize feature

- maybe something else that I forgot

Please try this before dismissing it! It really works well.

And please point out if these modifications break anything, I wasn't sure in a few places, especially the open space in window controls.