### PR TITLE
Stop twdisplay from opening a screen inside itself

### DIFF
--- a/server/display.c
+++ b/server/display.c
@@ -1228,6 +1228,14 @@ int main(int argc, char *argv[]) {
     TWDisplay = dpy ? CloneStr(dpy) : origTWDisplay;
     origTERM = CloneStr(getenv("TERM"));
     HOME = CloneStr(getenv("HOME"));
+
+    if (!strcmp(origTWDisplay, TWDisplay)) {
+        if (!force) {
+            printk("twdisplay: Aborting. Use option `-f' to open a display inside itself.\n");
+            TwClose();
+            return 1;
+        }
+    }
     
     InitSignals();
     InitTtysave();


### PR DESCRIPTION
This is not the only recursive pattern, but it is the most confusing one.
Often, lines with the same content are printed everywhere.
Since control is lost, this is confusing for starters.
For more experienced users, it's also good to stop them from self-harm.