### PR TITLE
Bugfix for an initialisation oversight

### DIFF
--- a/server/remote.c
+++ b/server/remote.c
@@ -50,7 +50,7 @@ static uldat FdListGrow(void) {
 	return NOSLOT;
     }
 
-    for (FdSize = oldsize+1; FdSize<size; FdSize++) {
+    for (FdSize = oldsize; FdSize<size; FdSize++) {
         newFdList[FdSize].Fd = NOFD;
     }
     


### PR DESCRIPTION
(This is something I ran into while adding ZMODEM support.  It caused infinite loops due to a non-initialised variable but it needs fixing in the general code too.  It's a simple off-by-one bug.)