### PR TITLE
Update hw_tty.c: for issue #44 (hw_tty without gpm: QUITTING without terminal being reset)

### DIFF
--- a/server/hw/hw_tty.c
+++ b/server/hw/hw_tty.c
@@ -573,6 +573,7 @@ static byte tty_InitHW(void) {
 	    HW->QuitMouse();
 	}
 	HW->QuitVideo();
+	tty_setioctl(tty_fd, &ttysave);
     } else if (tty_fd >= 0)
         tty_setioctl(tty_fd, &ttysave);
     


### PR DESCRIPTION
I am trying to solve the issue #44 (hw_tty without gpm: QUITTING without terminal being reset #44).

Just in case mouse support is not enabled, and user does not confirm to use the program without mouse, the server appears to end leaving the terminal in "raw mode", not "canonical mode".
This modification adds a line to restore the tty original status only for hw_tty, and only for this case.

Edited file: "twin / server / hw / hw_tty.c"
Added "tty_setioctl(tty_fd, &tty_save)" on line 576.

