### PR TITLE
server: remove 'const' modifier on return types

### DIFF
--- a/server/obj/window.h
+++ b/server/obj/window.h
@@ -106,7 +106,7 @@ public:
                       const trune *runes, const tcell *cells) OVERRIDE;
 
   /* Twindow */
-  const TwindowFn fn() const {
+  TwindowFn fn() const {
     return (TwindowFn)Fn;
   }
 


### PR DESCRIPTION
The 'const' modifier has no effect on return types. The 'const' modifying the return type can be removed.