### PR TITLE
server: fix TOCTOU filesystem race condition

### DIFF
--- a/server/socket.cpp
+++ b/server/socket.cpp
@@ -1926,23 +1926,29 @@ static byte CreateAuth(char *path) {
   int fd, got = -1;
   uldat len = 0;
 
-  if ((fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600)) >= 0 && chmod(path, 0600) == 0) {
-
-    len = GetRandomData();
-
-    if (len == AuthLen)
-      for (len = 0; len < AuthLen; len += got) {
-        got = write(fd, AuthData + len, AuthLen - len);
-        if (got < 0) {
-          if (errno == EINTR || errno == EWOULDBLOCK)
-            got = 0;
-          else
-            break;
-        }
-      }
-    close(fd);
+  fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+  if (fd < 0 || fchmod(fd, 0600) < 0) {
+    goto cleanup;
   }
 
+  len = GetRandomData();
+
+  if (len == AuthLen) {
+    for (len = 0; len < AuthLen; len += got) {
+      got = write(fd, AuthData + len, AuthLen - len);
+      if (got < 0) {
+        if (errno == EINTR || errno == EWOULDBLOCK)
+          got = 0;
+        else
+          break;
+      }
+    }
+  }
+
+cleanup:
+  if (fd >= 0) {
+    close(fd);
+  }
   return len == AuthLen ? ttrue : Error(SYSERROR);
 }
 


### PR DESCRIPTION
CreateAuth() opens a file and then, if the opening was successful, its permissions are changed with chmod.
However, an attacker might change the target of the file name between the initial opening and the permissions change, potentially changing the permissions of a different file.

This can be avoided by using fchmod with the file descriptor that was received from opening the file. This ensures that the permissions change is applied to the very same file that was opened.

Also, we need to close the file if open() succeeds but fchmod() fails.

Reference: CWE-367